### PR TITLE
check screen width >= 640px before focusing on input

### DIFF
--- a/src/components/atoms/TextInput.vue
+++ b/src/components/atoms/TextInput.vue
@@ -79,14 +79,17 @@ export default {
         context.emit("add-message", this.text);
         text.value = "";
         checkSendBtnActive();
+
+        //check if we're on mobile view
         if (
           Math.max(
             document.documentElement.clientWidth || 0,
             window.innerWidth || 0
           ) >= 640
         ) {
-          //check if we're on mobile view
           input.value.focus();
+        } else {
+          input.value.blur();
         }
       }
     }

--- a/src/components/atoms/TextInput.vue
+++ b/src/components/atoms/TextInput.vue
@@ -79,7 +79,15 @@ export default {
         context.emit("add-message", this.text);
         text.value = "";
         checkSendBtnActive();
-        input.value.focus();
+        if (
+          Math.max(
+            document.documentElement.clientWidth || 0,
+            window.innerWidth || 0
+          ) >= 640
+        ) {
+          //check if we're on mobile view
+          input.value.focus();
+        }
       }
     }
     function sendBtnText(btnText) {


### PR DESCRIPTION
## [VA-101](https://jira-dev.bdm-dev.dts-stn.com/browse/VA-101) 

### Description 
Checks if the screen width >= 640px (sm screen breakpoint/desktop view) before focusing on input. This way, it prevents the keyboard tray from staying up when sending a message when pressing the message button.

### Addtional notes
thanks [stack overflow](https://stackoverflow.com/questions/1248081/how-to-get-the-browser-viewport-dimensions) 