### PR TITLE
added unit tests for textinput

### DIFF
--- a/__tests__/components/atoms/TextInput.test.js
+++ b/__tests__/components/atoms/TextInput.test.js
@@ -1,0 +1,30 @@
+import { mount } from "@vue/test-utils";
+import { i18n } from "../../../i18n";
+import TextInput from "../../../src/components/atoms/TextInput";
+import ChatOptionButton from "../../../src/components/atoms/ChatOptionButton.vue";
+
+describe("TextInput component", () => {
+  const wrapper = mount(TextInput, {
+    global: {
+      plugins: [i18n],
+    },
+  });
+
+  it("2 ChatOptionButtons are rendered if there's 2 options supplied", async () => {
+    await wrapper.setProps({
+      buttonOptions: ["Yes", "No"],
+    });
+    expect(wrapper.findAllComponents(ChatOptionButton).length).toBe(2);
+  });
+
+  it("pressing ChatOptionButton emits add-message", async () => {
+    await wrapper.setProps({
+      buttonOptions: ["Yes"],
+    });
+    const quickReply = wrapper.findAll("button").filter((btn) => {
+      return btn.text() === "Yes";
+    })[0]; //get the chatoptionbutton
+    quickReply.trigger("click");
+    expect(wrapper.emitted("add-message")).toBeTruthy();
+  });
+});

--- a/__tests__/components/atoms/TextInput.test.js
+++ b/__tests__/components/atoms/TextInput.test.js
@@ -21,10 +21,29 @@ describe("TextInput component", () => {
     await wrapper.setProps({
       buttonOptions: ["Yes"],
     });
-    const quickReply = wrapper.findAll("button").filter((btn) => {
+    const quickReply = await wrapper.findAll("button").filter((btn) => {
       return btn.text() === "Yes";
     })[0]; //get the chatoptionbutton
-    quickReply.trigger("click");
+    await quickReply.trigger("click");
     expect(wrapper.emitted("add-message")).toBeTruthy();
+  });
+
+  describe("input methods are called properly", () => {
+    const input = wrapper.find("input");
+
+    it("keydown.up emits move-to-most-recent-message", async () => {
+      await input.trigger("keydown.up");
+      expect(wrapper.emitted("move-to-most-recent-message")).toBeTruthy();
+    });
+
+    it("blur emits reset-chat-window", async () => {
+      await input.trigger("blur");
+      expect(wrapper.emitted("reset-chat-window")).toBeTruthy();
+    });
+
+    it("keyup.enter emits add-message", async () => {
+      await input.trigger("keyup.enter");
+      expect(wrapper.emitted("add-message")).toBeTruthy();
+    });
   });
 });


### PR DESCRIPTION
## [VA-123](https://jira-dev.bdm-dev.dts-stn.com/browse/VA-123) (vcon-280 on the old instance)

### Description
Added tests for the textinput component.

### What to test for/How to test
Thanks to Sheila, this should be automatically run and tested. If it fails, then I need to change stuff up.

### Addtional Notes
I didn't test some things such as the send button's methods and the icon being changed as I think that's something that's more suitable for Cypress testing. 
I would've used `findComponent(ChatOptionButton).find("button").trigger("click")` in the button test, but it doesn't seem to let me use the `trigger()` method so I had to resort to looking through the available buttons and finding the one that matched with the prop (for future-proofing the test in case the order of buttons gets changed, for whatever reason).
