### PR TITLE
fixed focus outline contrast

### DIFF
--- a/src/components/atoms/PhaseBanner.vue
+++ b/src/components/atoms/PhaseBanner.vue
@@ -9,7 +9,10 @@
             {{ phase }}
           </div>
           <div className="pt-1 sm:pt-0 sm:mb-2 font-body sm:whitespace-nowrap">
-            <a className="underline text-white" :href="link">
+            <a
+              className="underline text-white focus-visible:ring-white"
+              :href="link"
+            >
               {{ linkText }}
             </a>
           </div>

--- a/src/components/molecules/TheSkipNav.vue
+++ b/src/components/molecules/TheSkipNav.vue
@@ -20,11 +20,13 @@
           p-2
           rounded
           block
-          outline-white
+          focus-within:outline-white
         "
         @click="toMain"
       >
-        <a href="#index-header">{{ $t("skipToMain") }}</a>
+        <a href="#index-header" class="ring-transparent">{{
+          $t("skipToMain")
+        }}</a>
       </li>
     </ul>
   </nav>


### PR DESCRIPTION
## [VA-128](https://jira-dev.bdm-dev.dts-stn.com/browse/VA-128)

### Description
Changed focus outline colour from being black to white, for better visibility on the "Back to Projects" link in the Phase banner.
Removed the black focus outline on the "Skip to main content" link. 
