### PR TITLE
obliterated remnants of alt text for decorative imagery

### DIFF
--- a/src/components/atoms/ConversationMessage.vue
+++ b/src/components/atoms/ConversationMessage.vue
@@ -32,7 +32,6 @@
       v-if="isLastMessage"
       ref="chatReaderIcon"
       :src="icons[senderIcon]"
-      :alt="senderIconAltText"
       class="h-6 w-10 absolute left-0 bottom-0"
     />
   </li>
@@ -44,7 +43,6 @@ export default {
   emits: ["return-to-chat-window"],
   props: {
     senderIcon: String,
-    senderIconAltText: String,
     isUser: Boolean,
     isLastMessage: Boolean,
     text: String,

--- a/src/components/atoms/ConversationMessage.vue
+++ b/src/components/atoms/ConversationMessage.vue
@@ -32,6 +32,7 @@
       v-if="isLastMessage"
       ref="chatReaderIcon"
       :src="icons[senderIcon]"
+      alt=""
       class="h-6 w-10 absolute left-0 bottom-0"
     />
   </li>

--- a/src/components/atoms/MessageHeader.vue
+++ b/src/components/atoms/MessageHeader.vue
@@ -11,16 +11,12 @@
       @focus="setBackIcon('BackFocused')"
       @focusout="setBackIcon('Back')"
     >
-      <img
-        :src="icons[backIcon]"
-        :alt="altText"
-        class="h-10 mt-auto w-10 mr-4"
-      />
+      <img :src="icons[backIcon]" alt="" class="h-10 mt-auto w-10 mr-4" />
     </button>
 
     <img
       :src="icons[imageName]"
-      :alt="altText"
+      alt=""
       class="h-10 mt-auto w-10"
       aria-hidden="true"
     />
@@ -35,7 +31,6 @@ import { ref, computed } from "vue";
 export default {
   props: {
     imageName: String,
-    altText: String,
     headerText: String,
   },
   setup() {

--- a/src/components/molecules/MessageList.vue
+++ b/src/components/molecules/MessageList.vue
@@ -8,7 +8,6 @@
     <message-header
       backIcon="Back"
       :imageName="mailObject.senderIcon"
-      :altText="mailObject.senderIconAltText"
       :headerText="mailObject.senderName"
     />
     <ul

--- a/src/components/organisms/ConversationWindow.vue
+++ b/src/components/organisms/ConversationWindow.vue
@@ -8,7 +8,6 @@
     <div class="w-full opacity-95 z-10 bg-white sm:opacity-100">
       <message-header
         :imageName="chatMessage.senderIcon"
-        :altText="chatMessage.senderIconAltText"
         :headerText="chatMessage.senderName"
       />
     </div>
@@ -56,7 +55,6 @@
           :senderName="chatMessage.senderName"
           :text="message.text"
           :senderIcon="chatMessage.senderIcon"
-          :senderIconAltText="chatMessage.senderIconAltText"
           :isLastMessage="index === chatMessage.messages.length - 1"
         />
         <ConversationFooter


### PR DESCRIPTION
## [VA-127](https://jira-dev.bdm-dev.dts-stn.com/browse/VA-127) 

### Description
Emptied alt text contents on decorative icons, and also removed the related props.

### What to test for/How to test
Go through all the icons that don't serve any purpose with the inspector. There should be no "name" as shown below
![image](https://user-images.githubusercontent.com/45071113/130508838-8b86775a-98cc-4dca-9c10-dbd40de3d5e3.png)


### Addtional Notes
Fun fact: 127, this PR's issue number, is a triple [Mersenne prime](https://en.wikipedia.org/wiki/Mersenne_prime)