### PR TITLE
added french footer info, added hidden timestamp for SRs in conversation

### DIFF
--- a/src/components/molecules/TheFooter.vue
+++ b/src/components/molecules/TheFooter.vue
@@ -12,7 +12,7 @@
           "
         >
           <!-- Hidden heading -->
-          <h2 class="sr-only p-1">Site Footer Information</h2>
+          <h2 class="sr-only p-1">{{ $t("siteFooter") }}</h2>
           <date-modified />
           <div class="flex justify-end sm:p-2">
             <img

--- a/src/components/organisms/ConversationWindow.vue
+++ b/src/components/organisms/ConversationWindow.vue
@@ -35,7 +35,11 @@
         "
       >
         <li>
+          <span class="sr-only">
+            {{ messageTimestamps.long }}
+          </span>
           <p
+            aria-hidden="true"
             class="
               text-center
               uppercase
@@ -45,7 +49,7 @@
               text-gray-dark
             "
           >
-            {{ messageTimestamp }}
+            {{ messageTimestamps.short }}
           </p>
         </li>
         <ConversationMessage
@@ -121,19 +125,30 @@ export default {
         ? null
         : messages[messages.length - 1].suggestedActions?.actions;
     });
-    const messageTimestamp = computed(() => {
+    const messageTimestamps = computed(() => {
       const msgs = chatMessage.value.messages;
       const lang = useI18n().locale.value;
-      const options = {
+      let date;
+      const shortOptions = {
         weekday: "short",
+        hour: "2-digit",
+        minute: "2-digit",
+      };
+      const longOptions = {
+        weekday: "long",
         hour: "2-digit",
         minute: "2-digit",
       };
       if (msgs?.length >= 1) {
         //create a timestamp using the oldest message sent by the bot
-        return new Date(msgs[0].timestamp).toLocaleString(lang, options);
+        date = new Date(msgs[0].timestamp);
+      } else {
+        date = new Date(); //use  current time if no messages exist
       }
-      return new Date().toLocaleString(lang, options); //return current time if no messages exist
+      return {
+        short: date.toLocaleString(lang, shortOptions),
+        long: date.toLocaleString(lang, longOptions),
+      };
     });
 
     function sendChatMessage(msg) {
@@ -207,7 +222,7 @@ export default {
       conversationWindow,
       focusOnInput,
       resetConversationWindow,
-      messageTimestamp,
+      messageTimestamps,
       shiftTabFromConversationWindowHandler,
     };
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -40,5 +40,6 @@
   "conversationWindowDesc": "Press enter to begin navigating through the chat messages and input box. Use the up and down arrow keys to navigate between each message, going all the way down lets you reach the input box. You may also use tab/shift+tab, and press shift+enter to view the latest chat message. Press escape to exit.",
 
   "backToProjectsLink": "https://alpha.service.canada.ca/projects",
-  "homeTitle": "Service Canada Labs – Virtual Assistant"
+  "homeTitle": "Service Canada Labs – Virtual Assistant",
+  "siteFooter": "Site Footer Information"
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -40,5 +40,6 @@
   "conversationWindowDesc": "(FR) Press enter to begin navigating through the chat messages and input box. Use the up and down arrow keys to navigate between each message, going all the way down lets you reach the input box. You may also use tab/shift+tab, and press shift+enter to view the latest chat message. Press escape to exit.",
 
   "backToProjectsLink": "https://alpha.service.canada.ca/fr/projects",
+  "siteFooter": "(FR) Site Footer Information",
   "homeTitle": "Laboratoires de Service Canada - Assistant virtuel"
 }


### PR DESCRIPTION
## [VA-129](https://jira-dev.bdm-dev.dts-stn.com/browse/VA-129) (JIRA issue)

### Description
Added missing translation key in the footer, timestamp in conversation window wasn't read out properly by screenreaders (read out "Mon. 12:34" as "Mon 12 34" instead of "Monday 12 34") so added hidden text to compensate.

### What to test for/How to test
Screenreaders should read out the above text properly now:
Steps:
1. Open screenreader of your choice
2. Navigate to relevant sections
3. Listen for the "FR" in the footer, make sure full day is read out on the timestamp
